### PR TITLE
CA-107919: Reduce memory usage when writing large RRDs.

### DIFF
--- a/test/dummy.ml
+++ b/test/dummy.ml
@@ -1,0 +1,22 @@
+open Rrd
+
+let _ =
+   let rra = rra_create CF_Average 100 1 0.5 in
+   let rra2 = rra_create CF_Average 100 10 0.5 in
+   let rra3 = rra_create CF_Average 100 100 0.5 in
+   let rra4 = rra_create CF_Average 100 1000 0.5 in
+   let ds = ds_create "foo" Gauge ~mrhb:10.0 (VT_Float 0.0) in
+   let ds2 = ds_create "bar" Gauge ~mrhb:10.0 (VT_Float 0.0) in
+   let ds3 = ds_create "baz" Gauge ~mrhb:10.0 (VT_Float 0.0) in
+   let ds4 = ds_create "boo" Gauge ~mrhb:10.0 (VT_Float 0.0) in
+   let rrd = rrd_create [|ds; ds2; ds3; ds4|] [|rra; rra2; rra3; rra4 |] 1L 1000000000.0 in
+   let id = fun x -> x in
+   for i=1 to 100000 do
+    let t = 1000000000.0 +. 0.7 *. (float_of_int i) in
+    let v1 = VT_Float (0.5 +. 0.5 *. sin ( t /. 10.0 )) in
+    let v2 = VT_Float (1.5 +. 0.5 *. cos ( t /. 80.0 )) in
+    let v3 = VT_Float (3.5 +. 0.5 *. sin ( t /. 700.0 )) in
+    let v4 = VT_Float (6.5 +. 0.5 *. cos ( t /. 5000.0 )) in
+    ds_update rrd t [|v1; v2; v3; v4|] [| id; id; id; id |] false
+   done;
+   to_file rrd "output.xml"

--- a/test/rewrite.ml
+++ b/test/rewrite.ml
@@ -1,0 +1,7 @@
+(* Read in an RRD, write it out again *)
+(* This is to test input/output code *)
+
+let _ =
+  let rrd = Rrd.of_file Sys.argv.(1) in
+  Rrd.to_file rrd (Printf.sprintf "%s.new" Sys.argv.(1))
+

--- a/xcp-rrd.obuild
+++ b/xcp-rrd.obuild
@@ -11,3 +11,13 @@ library xcp-rrd
   build-deps: stdext, rpclib, rpclib.syntax
   pp: camlp4o
 
+executable rewrite
+  src-dir: test
+  main: rewrite.ml
+  build-deps: xcp-rrd
+
+executable dummy
+  src-dir: test
+  main: dummy.ml
+  build-deps: xcp-rrd
+


### PR DESCRIPTION
Previously we temporarily allocated an enormous data structure in
memory with partially applied functions all over the place. Now
we don't.

This commit also adds a couple of test programs and some helper
functions to Rrd (of_file and to_file) and removes some dead code.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
