### PR TITLE
Fix build on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,11 @@ dist/build/lib-rrd/rrd.cmxa:
 	obuild configure
 	obuild build
 
+.PHONY: install
 install:
 	ocamlfind install xcp-rrd lib/META $(wildcard dist/build/lib-xcp-rrd/*)
 
+.PHONY: uninstall
 uninstall:
 	ocamlfind remove xcp-rrd
 


### PR DESCRIPTION
Makefile: 'install' and 'uninstall' are both phoney targets

(because they don't create any artifacts whose timestamps are tracked
by make)

Signed-off-by: David Scott dave.scott@citrix.com
