### PR TITLE
CA-142415: Distinguish rebooting from 32-bit-wrapping for perf data

### DIFF
--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -266,10 +266,36 @@ let process_ds_value ds value interval new_domid =
 						else
 							match ds.ds_last, value with
 							| VT_Int64 x, VT_Int64 y ->
-								let result = (Int64.sub y x) in
-								let result = if result < 0L then Int64.add result 0x100000000L else result in (* for wrapping 32 bit counters *)
-								Int64.to_float result
-							| VT_Float x, VT_Float y -> y -. x
+									let diff = (Int64.sub y x) in
+									let result =
+										if diff < 0L then
+											(* The current value would be less than the previous one in two scenario:
+											 *   1) the counter value exceeds 32-bit integer and wraps;
+											 *   2) one or more of the VMs rebooted then the counters of those VMs
+											 *      restarted from 0;
+											 *
+											 * For VM level counters they can be easily distinguished as new_domid will
+											 * be set to `true' in case of VM rebooting.
+											 *
+											 * While for host level counters we have no way to exactly figure out one
+											 * from another. However we can assume that the counters would not
+											 * accumulate very fast and the difference of two successive values (if no
+											 * rebooting) would not exceed 0x80000000.
+											 *
+											 * Even though in the second situation the correct value is unattainable.
+											 * So set to ZERO to mitigate the abnormal.
+											 *)
+											if diff < -0x80000000L then
+												Int64.add diff 0x100000000L (* for wrapping 32 bit counters *)
+											else
+												0L (* values reset to zero due to VM rebooting *)
+										else
+											diff
+									in
+									Int64.to_float result
+							| VT_Float x, VT_Float y ->
+									(* value reset to zero due to VM rebooting, see comments above*)
+									if y < x then 0.0 else y -. x
 							| VT_Unknown, _ -> nan
 							| _, VT_Unknown -> nan
 							| _ -> failwith ("Bad type updating ds: "^ds.ds_name)


### PR DESCRIPTION
Some performance statistic data (such as iops, throughput) will be
reset to zero due to the VM rebooting. Those performance data may
also decrease if the values exceed the 32-bit limit and wrap.

For VM level counters they can be easily distinguished. While for host
level counters we have no way to exactly figure out one from another.

Based on an assumption that those performance data would not accumulate
rapidly so that we have a way to distinguish them from each other.

Signed-off-by: Kaifeng Zhu kaifeng.zhu@citrix.com
