### PR TITLE
Make the API easier to use

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -13,7 +13,7 @@ Library rrd
   CompiledObject:     best
   Path:               lib
   Findlibname:        rrd
-  Modules:            Rrd, Rrd_fring, Rrd_updates, Rrd_utils
+  Modules:            Rrd, Rrd_fring, Rrd_updates, Rrd_utils, Rrd_timescales
   BuildDepends:       rpclib, rpclib.syntax
 
 Library rrd_unix

--- a/lib/rrd_timescales.ml
+++ b/lib/rrd_timescales.ml
@@ -1,0 +1,39 @@
+(*
+ * Copyright (C) 2015 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+(*
+ * Timescales: this allows an RRD server to advertise which Timescales
+ * are available, to avoid clients having to already know or guess.
+ *)
+
+type t = {
+	name: string;
+	num_intervals: int;
+	interval_in_steps: int;
+} with rpc
+
+type ts = t list with rpc
+
+let make ~name ~num_intervals ~interval_in_steps () =
+	{ name; num_intervals; interval_in_steps }
+
+let name_of t = t.name
+
+let to_span t =
+	t.num_intervals * t.interval_in_steps * 5 (* ??? *)
+
+let interval_to_span t =
+	t.interval_in_steps * 5
+
+let to_json ts = Jsonrpc.to_string (rpc_of_ts ts)
+let of_json txt = ts_of_rpc (Jsonrpc.of_string txt)

--- a/lib/rrd_timescales.mli
+++ b/lib/rrd_timescales.mli
@@ -1,0 +1,39 @@
+(*
+ * Copyright (C) 2015 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+(*
+ * Timescales: this allows an RRD server to advertise which Timescales
+ * are available, to avoid clients having to already know or guess.
+ *)
+
+
+type t = {
+	name: string;
+	num_intervals: int;
+	interval_in_steps: int;
+}
+
+val make: name:string -> num_intervals:int -> interval_in_steps:int -> unit -> t
+
+val name_of: t -> string
+
+val to_span: t -> int
+(** Total length of time covered by the archive *)
+
+val interval_to_span: t -> int
+(** Length of time in one interval (clients requesting updates should poll at
+    most every interval) *)
+
+val to_json: t list -> string
+
+val of_json: string -> t list

--- a/lib/rrd_updates.ml
+++ b/lib/rrd_updates.ml
@@ -181,7 +181,13 @@ let create_multi prefixandrrds start interval cfopt =
   (* Sanity - make sure the RRDs are homogeneous *)
   let prefixandrrds = List.filter (fun (prefix,rrd) -> rrd.timestep = first_rrd.timestep) prefixandrrds in
 
-  let rras = 
+  (* Treat -ve start values as relative to the latest update. *)
+  let start =
+    prefixandrrds
+    |> List.map (fun (_, rrd) -> if start < 0L then Int64.(add start (of_float rrd.last_updated)) else start)
+    |> List.fold_left min Int64.max_int in
+
+  let rras =
     (List.map
        (fun (prefix,rrd) ->
           (* Find the rrds that satisfy the requirements *)


### PR DESCRIPTION
- interpret -ve `start` as relative to now, so a client doesn't need another way to determine the server time in order to make a well-formed request
- add a notion of a `timescale` (i.e. details about the data contained within an individual archive): this allows a client to determine valid values for the `interval` parameter without needing the server's policy to be hardcoded in the client.