### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-opam.sh
 sudo: true
 env:
-        - OCAML_VERSION=4.02 PACKAGE=xapi-rrd FORK_USER=xapi-project EXTRA_REMOTES=git://github.com/xapi-project/opam-repo-dev
+        - OCAML_VERSION=4.02 PACKAGE=xapi-rrd EXTRA_REMOTES=git://github.com/xapi-project/opam-repo-dev


### PR DESCRIPTION
Fix Travis build by removing the `FORK_USER` variable from `.travis.yml` - now the builds work fine.

The travis build fails because we do not have a fork of the `ocaml-ci-scripts` repository, which `.travis-opam.sh` tries to use if `FORK_USER` is specified.

We do have a fork of `ocaml-ci-scripts` with a different name, called
["`ocaml-travisci-skeleton`"](https://github.com/xapi-project/ocaml-travisci-skeleton), but this seems to be outdated.