### PR TITLE
Update version in the oasis file to prepare for 1.0.1 release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+1.0.1 (16-Jun-2017):
+* Use new ppx deriver in place of old camlp4 one
+* Fix deprecation warnings
+
 1.0.0 (27-Apr-2016):
 * Declare this package stable
 

--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,0 @@
-The easiest install method is via opam:
-
-    opam init
-    opam remote add xen-org git://github.com/xen-org/opam-repo-dev
-    opam install xcp-rrd
-

--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
 Round-Robin Datasources (RRDs) for OCaml.
-
-Requires [rpclib](https://github.com/samoht/ocaml-rpc)

--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.3
 Name:        xcp-rrd
-Version:     1.0.0
+Version:     1.0.1
 Synopsis:    RRD manipulation library
 Authors:     Jonathan Ludlam, David Scott, John Else
 License:     ISC


### PR DESCRIPTION
The ppx version has never been released and the oasis file version was incorrect (1.0.0 had version 0.12.0 and master had version 1.0.0). We introduce version 1.0.1 and release a new xapi-rrd 1.0.1. No breaking change is present, but the use of ppx makes sure that this package compiles correctly with any recent version of ocaml.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>