### PR TITLE
Add dependency on rpclib.json

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -14,7 +14,7 @@ Library rrd
   Path:               lib
   Findlibname:        rrd
   Modules:            Rrd, Rrd_fring, Rrd_updates, Rrd_utils, Rrd_timescales
-  BuildDepends:       rpclib, ppx_deriving_rpc
+  BuildDepends:       rpclib.json, ppx_deriving_rpc
 
 Library rrd_unix
   Pack:               false


### PR DESCRIPTION
Since rpclib.1.9.51, the Jsonrpc module has moved to a subpackage.
See the build breakage here:

https://travis-ci.org/mirage/mirage-www/jobs/246491914

Signed-off-by: David Scott <dave@recoil.org>