### PR TITLE
CA-315952 fix JSON output

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -7,6 +7,7 @@
     bigarray
     rpclib.json
     xmlm
+    ezjsonm
   )
   (preprocess (pps ppx_deriving_rpc))
 )

--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -711,9 +711,13 @@ module Json = struct
       ; "minimal_hearbeat"   , string "%s" (Utils.f_to_s ds.ds_mrhb)
       ; "min"                , string "%s" (Utils.f_to_s ds.ds_min)
       ; "max"                , string "%s" (Utils.f_to_s ds.ds_max)
-      ; "last_ds"            , float 0.0
-      ; "value"              , float 0.0
-      ; "unknown_sec"        , float 0.0
+      ; "last_ds",           ( match ds.ds_last with
+                             | VT_Float x -> string "%s" (Utils.f_to_s x)
+                             | VT_Int64 x -> string "%Ld" x
+                             | _          -> float 0.0
+                             )
+      ; "value"              , string "%s" (Utils.f_to_s ds.ds_value)
+      ; "unknown_sec"        , string "%d" (int_of_float ds.ds_unknown_sec)
       ]
 
   let cdp x =

--- a/xapi-rrd.opam
+++ b/xapi-rrd.opam
@@ -19,6 +19,7 @@ depends: [
   "rpc" {>= "1.9.51" & < "5.0.0"} | ("rpclib" & "ppx_deriving_rpc")
   "xmlm"
   "uuidm"
+  "ezjsonm"
   "ounit" {with-test}
 ]
 synopsis: "RRD library for use with xapi"


### PR DESCRIPTION
Json so far is generated in a naive way that violates the Json
specification by ignoring basic quoting rules. This commit delegates
generation of Json to a library instead and should be much more
declarative. Furthermore, it emits data points that previously were hard
coded in the Json output.

