### PR TITLE
CA-322008: Stop treating Derive datasources as counters

### DIFF
--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -263,7 +263,6 @@ let process_ds_value ds value interval new_domid =
               match ds.ds_last, value with
               | VT_Int64 x, VT_Int64 y ->
                 let result = (Int64.sub y x) in
-                let result = if result < 0L then Int64.add result 0x100000000L else result in (* for wrapping 32 bit counters *)
                 Int64.to_float result
               | VT_Float x, VT_Float y -> y -. x
               | VT_Unknown, _ -> nan

--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -176,9 +176,9 @@ let do_cfs rra start_pdp_offset pdps =
     if Utils.isnan pdps.(i)
     then begin
       (* CDP is an accumulator for the average. If we've got some unknowns, we need to
-         			   renormalize. ie, CDP contains \sum_{i=0}^j{ (1/n) x_i} where n is the number of
-         			   values we expect to have. If we have unknowns, we need to multiply the whole
-         			   thing by \frac{n_{old}}{n_{new}} *)
+         renormalize. ie, CDP contains \sum_{i=0}^j{ (1/n) x_i} where n is the number of
+         values we expect to have. If we have unknowns, we need to multiply the whole
+         thing by \frac{n_{old}}{n_{new}} *)
       let olddiv = rra.rra_pdp_cnt - cdp.cdp_unknown_pdps in
       let newdiv = olddiv - start_pdp_offset in
       if newdiv > 0 then (
@@ -203,12 +203,12 @@ let rra_update rrd proc_pdp_st elapsed_pdp_st pdps =
     if rra_step_cnt > 0 then
       begin
         (* When writing multiple CDP values into the archive, the
-           				   first one (primary) is calculated using the values we
-           				   already had accumulated from the last update, whereas any
-           				   subsequent values (secondary) are calculated just using the
-           				   current PDP. It turns out that the secondary values are
-           				   simply the PDPs as whichever CF is used, a CDP of many
-           				   repeated values is simply the value itself. *)
+           first one (primary) is calculated using the values we
+           already had accumulated from the last update, whereas any
+           subsequent values (secondary) are calculated just using the
+           current PDP. It turns out that the secondary values are
+           simply the PDPs as whichever CF is used, a CDP of many
+           repeated values is simply the value itself. *)
         let primaries = Array.map (fun cdp ->
             if cdp.cdp_unknown_pdps <= (int_of_float (rra.rra_xff *. float_of_int rra.rra_pdp_cnt))
             then cdp.cdp_value
@@ -234,7 +234,7 @@ let rra_update rrd proc_pdp_st elapsed_pdp_st pdps =
 
 (* We assume that the data being given is of the form of a rate; that is,
    it's dependent on the time interval between updates. To be able to
-   deal with guage DSs, we multiply by the interval so that it cancels
+   deal with gauge DSs, we multiply by the interval so that it cancels
    the subsequent divide by interval later on *)
 let process_ds_value ds value interval new_domid =
   if interval > ds.ds_mrhb
@@ -265,7 +265,7 @@ let process_ds_value ds value interval new_domid =
             | VT_Float x, VT_Float y -> y -. x
             | VT_Unknown, _ -> nan
             | _, VT_Unknown -> nan
-            | _ -> failwith ("Bad type updating ds: "^ds.ds_name)
+            | _ -> failwith ("Bad type updating ds: " ^ ds.ds_name)
           end
       in
       ds.ds_last <- value;
@@ -286,9 +286,9 @@ let ds_update rrd timestamp values transforms new_domid =
   let elapsed_pdp_st = Int64.to_int ((occu_pdp_st --- proc_pdp_st) /// rrd.timestep) in
 
   (* if we're due one or more PDPs, pre_int is the amount of the
-     	   current update interval that will be used in calculating them, and
-     	   post_int is the amount left over
-      this step. If a PDP isn't post is what's left over *)
+     current update interval that will be used in calculating them, and
+     post_int is the amount left over
+     this step. If a PDP isn't post is what's left over *)
   let pre_int, post_int =
     if elapsed_pdp_st > 0 then
       let pre = interval -. occu_pdp_age in
@@ -302,7 +302,6 @@ let ds_update rrd timestamp values transforms new_domid =
 
   (* Calculate the values we're going to store based on the input data and the type of the DS *)
   let v2s = Array.mapi (fun i value -> process_ds_value rrd.rrd_dss.(i) value interval new_domid) values in
-  (*  debug "Got values: %s\n" (String.concat "," (Array.to_list (Array.mapi (fun i p -> Printf.sprintf "(%s: %f)" rrd.rrd_dss.(i).ds_name p) v2s)));*)
   (* Update the PDP accumulators up until the most recent PDP *)
   Array.iteri
     (fun i value ->

--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -320,15 +320,12 @@ let ds_update rrd timestamp values transforms new_domid =
           then nan
           else
             let raw = ds.ds_value /. (Int64.to_float (occu_pdp_st --- proc_pdp_st) -. ds.ds_unknown_sec) in
-            let raw =
-              if raw < ds.ds_min
-              then ds.ds_min
-              else if raw > ds.ds_max
-              then ds.ds_max
-              else raw
-            in
-            (* Here is where we apply the transform *)
-            transforms.(i) raw
+            (* Apply the transform after the raw value has been calculated *)
+            let raw = transforms.(i) raw in
+            (* Make sure the values are not out of bounds after all the processing *)
+            if raw < ds.ds_min || raw > ds.ds_max
+            then nan
+            else raw
         ) rrd.rrd_dss in
 
       rra_update rrd proc_pdp_st elapsed_pdp_st pdps;

--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -237,37 +237,32 @@ let process_ds_value ds value interval new_domid =
   else
     begin
       let rate =
-        match ds.ds_ty with
-        | Absolute ->
+        match ds.ds_ty, new_domid with
+        | Absolute, _
+        | Derive, true ->
           begin
             match value with
             | VT_Int64 y -> Int64.to_float y
             | VT_Float y -> y
             | VT_Unknown -> nan
           end
-        | Gauge ->
+        | Gauge, _ ->
           begin
             match value with
             | VT_Int64 y -> (Int64.to_float y) *. interval
             | VT_Float y -> y *. interval
             | VT_Unknown -> nan
           end
-        | Derive ->
+        | Derive, false ->
           begin
-            if new_domid then
-              match value with
-              | VT_Int64 y -> Int64.to_float y
-              | VT_Float y -> y
-              | VT_Unknown -> nan
-            else
-              match ds.ds_last, value with
-              | VT_Int64 x, VT_Int64 y ->
-                let result = (Int64.sub y x) in
-                Int64.to_float result
-              | VT_Float x, VT_Float y -> y -. x
-              | VT_Unknown, _ -> nan
-              | _, VT_Unknown -> nan
-              | _ -> failwith ("Bad type updating ds: "^ds.ds_name)
+            match ds.ds_last, value with
+            | VT_Int64 x, VT_Int64 y ->
+              let result = (Int64.sub y x) in
+              Int64.to_float result
+            | VT_Float x, VT_Float y -> y -. x
+            | VT_Unknown, _ -> nan
+            | _, VT_Unknown -> nan
+            | _ -> failwith ("Bad type updating ds: "^ds.ds_name)
           end
       in
       ds.ds_last <- value;


### PR DESCRIPTION
This was creating values unreasonable values in Round-robin Archives.

There is still related behaviour to fix: out-of-range values should be treated as unknowns instead of clamped: they are abnormalities and should be treated as such.

Depends on https://github.com/xapi-project/xcp-rrd/pull/30