### PR TITLE
CA-329043: Avoid introducing out-of-range values to rras

### DIFF
--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -229,9 +229,8 @@ let rra_update rrd proc_pdp_st elapsed_pdp_st pdps =
         let new_start_pdp_offset = (elapsed_pdp_st - start_pdp_offset) mod rra.rra_pdp_cnt in
         Array.iteri (fun i cdp ->
           let ds = rrd.rrd_dss.(i) in
-          let cdp_init = cf_init_value rra.rra_cf ds in
           cdp.cdp_unknown_pdps <- 0;
-          cdp.cdp_value <- cdp_init
+          cdp.cdp_value <- cf_init_value rra.rra_cf ds
         ) rra.rra_cdps;
         do_cfs rra new_start_pdp_offset pdps;
         match rra.rra_updatehook with None -> () | Some f -> f rrd rra_step_cnt

--- a/lib_test/unit_tests.ml
+++ b/lib_test/unit_tests.ml
@@ -138,6 +138,32 @@ let ca_322008_rrd =
   done;
   rrd
 
+
+let ca_329043_rrd =
+  let init_time = 0. in
+
+  let rra1 = rra_create CF_Average 3 1 0.5 in
+  let rra2 = rra_create CF_Min     3 1 0.5 in
+  let rra3 = rra_create CF_Max     3 1 0.5 in
+  let ds = ds_create "derive_with_min" ~min:0. ~max:1. Derive VT_Unknown in
+
+  let rrd = rrd_create [|ds|] [|rra1; rra2; rra3|] 5L init_time in
+
+  let id = fun x -> x in
+
+  let v_of_t t =
+    if t = 5. then
+      VT_Int64 0L
+    else
+      VT_Int64 Int64.(of_float t)
+  in
+  for i = 1 to 4 do
+    let t = 5. *. (init_time +. float_of_int i) in
+    let v = v_of_t t in
+    ds_update rrd t [|v|] [|id|] (i = 0);
+  done;
+  rrd
+
 let test_ca_322008 () =
   let rrd = ca_322008_rrd in
 
@@ -168,5 +194,6 @@ let () =
   Alcotest.run "Test RRD library" [
     "Gauge RRD", rrd_suite gauge_rrd;
     "RRD for CA-322008", rrd_suite ca_322008_rrd;
+    "RRD for CA-329043", rrd_suite ca_329043_rrd;
     "Regressions", regression_suite;
   ]


### PR DESCRIPTION
When a datasource introduces a value to a timeseries that produces and out-of-range rate, the series in the archives needs another whole cycle to stabilize.

When setting the both a minimum and a maximum to the timeseries do not default to showing infinities and clamp the values to the allowed range.