### PR TITLE
CA-322008 backport: Report out-of-bounds PDP values as NaN

### DIFF
--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -263,7 +263,6 @@ let process_ds_value ds value interval new_domid =
               match ds.ds_last, value with
               | VT_Int64 x, VT_Int64 y ->
                 let result = (Int64.sub y x) in
-                let result = if result < 0L then Int64.add result 0x100000000L else result in (* for wrapping 32 bit counters *)
                 Int64.to_float result
               | VT_Float x, VT_Float y -> y -. x
               | VT_Unknown, _ -> nan

--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -40,6 +40,11 @@ type sampling_frequency = Five_Seconds [@@deriving rpc]
 
 (* utility *)
 
+let ( +++ ) = Int64.add
+let ( --- ) = Int64.sub
+let ( *** ) = Int64.mul
+let ( /// ) = Int64.div
+
 let cf_type_of_string s =
   match s with
   | "AVERAGE" -> CF_Average
@@ -160,7 +165,7 @@ let copy_rrd x =
 
 (** Helper function to get the start time and age of the current/last PDP *)
 let get_times time timestep =
-  let starttime = Int64.mul timestep (Int64.div (Int64.of_float time) timestep) in
+  let starttime = timestep *** ((Int64.of_float time) /// timestep) in
   let age = time -. (Int64.to_float starttime) in
   (starttime, age)
 
@@ -192,7 +197,7 @@ let do_cfs rra start_pdp_offset pdps =
 let rra_update rrd proc_pdp_st elapsed_pdp_st pdps =
   (*  debug "rra_update";*)
   let updatefn rra =
-    let start_pdp_offset = rra.rra_pdp_cnt - (Int64.to_int (Int64.rem (Int64.div proc_pdp_st rrd.timestep) (Int64.of_int rra.rra_pdp_cnt))) in
+    let start_pdp_offset = rra.rra_pdp_cnt - Int64.(to_int (rem (proc_pdp_st /// rrd.timestep) (of_int rra.rra_pdp_cnt))) in
     let rra_step_cnt = if elapsed_pdp_st < start_pdp_offset then 0 else (elapsed_pdp_st - start_pdp_offset) / rra.rra_pdp_cnt + 1 in
     do_cfs rra (min start_pdp_offset elapsed_pdp_st) pdps;
     if rra_step_cnt > 0 then
@@ -256,9 +261,7 @@ let process_ds_value ds value interval new_domid =
         | Derive, false ->
           begin
               match ds.ds_last, value with
-              | VT_Int64 x, VT_Int64 y ->
-                let result = (Int64.sub y x) in
-                Int64.to_float result
+            | VT_Int64 x, VT_Int64 y -> Int64.to_float (y --- x)
               | VT_Float x, VT_Float y -> y -. x
               | VT_Unknown, _ -> nan
               | _, VT_Unknown -> nan
@@ -280,7 +283,7 @@ let ds_update rrd timestamp values transforms new_domid =
   let occu_pdp_st, occu_pdp_age = get_times timestamp rrd.timestep in
 
   (* The number of pdps that should result from this update *)
-  let elapsed_pdp_st = Int64.to_int (Int64.div (Int64.sub occu_pdp_st proc_pdp_st) rrd.timestep) in
+  let elapsed_pdp_st = Int64.to_int ((occu_pdp_st --- proc_pdp_st) /// rrd.timestep) in
 
   (* if we're due one or more PDPs, pre_int is the amount of the
      	   current update interval that will be used in calculating them, and
@@ -317,7 +320,7 @@ let ds_update rrd timestamp values transforms new_domid =
           if interval > ds.ds_mrhb
           then nan
           else
-            let raw = ds.ds_value /. (Int64.to_float (Int64.sub occu_pdp_st proc_pdp_st) -. ds.ds_unknown_sec) in
+            let raw = ds.ds_value /. (Int64.to_float (occu_pdp_st --- proc_pdp_st) -. ds.ds_unknown_sec) in
             let raw =
               if raw < ds.ds_min
               then ds.ds_min
@@ -415,7 +418,7 @@ let rrd_create dss rras timestep inittime =
 
 let rrd_add_ds rrd now newds =
   if List.mem newds.ds_name (ds_names rrd) then rrd else
-    let npdps = Int64.div (Int64.of_float now) rrd.timestep in
+    let npdps = Int64.of_float now /// rrd.timestep in
     {rrd with
      rrd_dss = Array.append rrd.rrd_dss [|newds|];
      rrd_rras = Array.map (fun rra ->
@@ -452,7 +455,7 @@ let find_best_rras rrd pdp_interval cf start =
   (if List.length rras = 0 then raise No_RRA_Available);
   let (last_pdp_time,age) = get_times rrd.last_updated rrd.timestep in
   let contains_time t rra =
-    let lasttime = Int64.sub last_pdp_time (Int64.mul rrd.timestep (Int64.of_int (rra.rra_row_cnt * rra.rra_pdp_cnt))) in
+    let lasttime = last_pdp_time --- rrd.timestep *** (Int64.of_int (rra.rra_row_cnt * rra.rra_pdp_cnt)) in
     (rra.rra_pdp_cnt >= pdp_interval) && (t > lasttime)
   in
   try
@@ -463,7 +466,7 @@ let find_best_rras rrd pdp_interval cf start =
     ok_rras
   with _ ->
     let rra = List.hd (List.rev rras) in
-    let newstarttime = Int64.add 1L (Int64.sub last_pdp_time (Int64.mul rrd.timestep (Int64.of_int (rra.rra_row_cnt * rra.rra_pdp_cnt)))) in
+    let newstarttime = 1L +++ last_pdp_time --- rrd.timestep *** (Int64.of_int (rra.rra_row_cnt * rra.rra_pdp_cnt)) in
     List.filter (contains_time newstarttime) rras
 
 

--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -237,29 +237,24 @@ let process_ds_value ds value interval new_domid =
   else
     begin
       let rate =
-        match ds.ds_ty with
-        | Absolute ->
+        match ds.ds_ty, new_domid with
+        | Absolute, _
+        | Derive, true ->
           begin
             match value with
             | VT_Int64 y -> Int64.to_float y
             | VT_Float y -> y
             | VT_Unknown -> nan
           end
-        | Gauge ->
+        | Gauge, _ ->
           begin
             match value with
             | VT_Int64 y -> (Int64.to_float y) *. interval
             | VT_Float y -> y *. interval
             | VT_Unknown -> nan
           end
-        | Derive ->
+        | Derive, false ->
           begin
-            if new_domid then
-              match value with
-              | VT_Int64 y -> Int64.to_float y
-              | VT_Float y -> y
-              | VT_Unknown -> nan
-            else
               match ds.ds_last, value with
               | VT_Int64 x, VT_Int64 y ->
                 let result = (Int64.sub y x) in

--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -320,15 +320,12 @@ let ds_update rrd timestamp values transforms new_domid =
           then nan
           else
             let raw = ds.ds_value /. (Int64.to_float (occu_pdp_st --- proc_pdp_st) -. ds.ds_unknown_sec) in
-            let raw =
-              if raw < ds.ds_min
-              then ds.ds_min
-              else if raw > ds.ds_max
-              then ds.ds_max
+            (* Apply the transform after the raw value has been calculated *)
+            let raw = transforms.(i) raw in
+            (* Make sure the values are not out of bounds after all the processing *)
+            if raw < ds.ds_min || raw > ds.ds_max
+            then nan
               else raw
-            in
-            (* Here is where we apply the transform *)
-            transforms.(i) raw
         ) rrd.rrd_dss in
 
       rra_update rrd proc_pdp_st elapsed_pdp_st pdps;

--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -234,7 +234,7 @@ let rra_update rrd proc_pdp_st elapsed_pdp_st pdps =
 
 (* We assume that the data being given is of the form of a rate; that is,
    it's dependent on the time interval between updates. To be able to
-   deal with guage DSs, we multiply by the interval so that it cancels
+   deal with gauge DSs, we multiply by the interval so that it cancels
    the subsequent divide by interval later on *)
 let process_ds_value ds value interval new_domid =
   if interval > ds.ds_mrhb
@@ -302,7 +302,6 @@ let ds_update rrd timestamp values transforms new_domid =
 
   (* Calculate the values we're going to store based on the input data and the type of the DS *)
   let v2s = Array.mapi (fun i value -> process_ds_value rrd.rrd_dss.(i) value interval new_domid) values in
-  (*  debug "Got values: %s\n" (String.concat "," (Array.to_list (Array.mapi (fun i p -> Printf.sprintf "(%s: %f)" rrd.rrd_dss.(i).ds_name p) v2s)));*)
   (* Update the PDP accumulators up until the most recent PDP *)
   Array.iteri
     (fun i value ->


### PR DESCRIPTION
Backport of 4a86fb57d3ba64017b3aa406e254df5078099bbb 

    Previously the values were just clamped before being applied the
    transform function from the client.
    
    Now the values marked as unknown values after having the transform
    applied, in case the transforms do not check for out-of-bounds values.
    
    Treating out-of-bounds values as Unknown matches rrdtool's behaviour.
