### PR TITLE
Remove constraint {>= "1.9.51"} on rpc version

### DIFF
--- a/opam
+++ b/opam
@@ -24,7 +24,7 @@ depends: [
   "oasis"     {build}
   "base-bigarray"
   "base-unix"
-  "rpc" {>= "1.9.51"}
+  "rpc"
   "uuidm"
   "xmlm"
   "ounit" {test}


### PR DESCRIPTION
The constraint "rpc" {>= "1.9.51"} is not required and causes build
failures in xs-opam on the Havana branch as it can't be satisfied.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>