### PR TITLE
Remove duplicated and unused code around file descriptors and (de)serialization

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -7,7 +7,7 @@
     bigarray
     rpclib.json
     xmlm
-    ezjsonm
+    yojson
   )
   (preprocess (pps ppx_deriving_rpc))
 )

--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -257,7 +257,8 @@ let rra_update rrd proc_pdp_st elapsed_pdp_st pdps =
     let start_pdp_offset =
       rra.rra_pdp_cnt
       - Int64.(
-          to_int (rem (proc_pdp_st /// rrd.timestep) (of_int rra.rra_pdp_cnt)))
+          to_int (rem (proc_pdp_st /// rrd.timestep) (of_int rra.rra_pdp_cnt))
+        )
     in
     let rra_step_cnt =
       if elapsed_pdp_st < start_pdp_offset then
@@ -283,7 +284,8 @@ let rra_update rrd proc_pdp_st elapsed_pdp_st pdps =
             then
               cdp.cdp_value
             else
-              nan)
+              nan
+          )
           rra.rra_cdps
       in
       let secondaries = pdps in
@@ -303,7 +305,8 @@ let rra_update rrd proc_pdp_st elapsed_pdp_st pdps =
           let ds = rrd.rrd_dss.(i) in
           let cdp_init = cf_init_value rra.rra_cf ds in
           cdp.cdp_unknown_pdps <- 0 ;
-          cdp.cdp_value <- cdp_init)
+          cdp.cdp_value <- cdp_init
+        )
         rra.rra_cdps ;
       do_cfs rra new_start_pdp_offset pdps ;
       match rra.rra_updatehook with None -> () | Some f -> f rrd rra_step_cnt
@@ -393,7 +396,8 @@ let ds_update rrd timestamp values transforms new_domid =
       if Utils.isnan value then
         ds.ds_unknown_sec <- pre_int
       else
-        ds.ds_value <- ds.ds_value +. (pre_int *. value /. interval))
+        ds.ds_value <- ds.ds_value +. (pre_int *. value /. interval)
+    )
     v2s ;
 
   (* If we've passed a PDP point, we need to update the RRAs *)
@@ -417,7 +421,8 @@ let ds_update rrd timestamp values transforms new_domid =
             if raw < ds.ds_min || raw > ds.ds_max then
               nan
             else
-              raw)
+              raw
+        )
         rrd.rrd_dss
     in
 
@@ -433,7 +438,8 @@ let ds_update rrd timestamp values transforms new_domid =
         ) else (
           ds.ds_value <- post_int *. value /. interval ;
           ds.ds_unknown_sec <- 0.0
-        ))
+        )
+      )
       v2s
   )
 
@@ -444,13 +450,15 @@ let ds_update_named rrd timestamp ~new_domid valuesandtransforms =
   let ds_values =
     Array.map
       (fun name ->
-        try fst (List.assoc name valuesandtransforms) with _ -> VT_Unknown)
+        try fst (List.assoc name valuesandtransforms) with _ -> VT_Unknown
+      )
       ds_names
   in
   let ds_transforms =
     Array.map
       (fun name ->
-        try snd (List.assoc name valuesandtransforms) with _ -> identity)
+        try snd (List.assoc name valuesandtransforms) with _ -> identity
+      )
       ds_names
   in
   ds_update rrd timestamp ds_values ds_transforms new_domid
@@ -502,13 +510,16 @@ let rrd_create dss rras timestep inittime =
               rra_data=
                 Array.init (Array.length dss) (fun i ->
                     let ds = dss.(i) in
-                    Fring.make rra.rra_row_cnt nan ds.ds_min ds.ds_max)
+                    Fring.make rra.rra_row_cnt nan ds.ds_min ds.ds_max
+                )
             ; rra_cdps=
                 Array.init (Array.length dss) (fun i ->
                     let ds = dss.(i) in
                     let cdp_init = cf_init_value rra.rra_cf ds in
-                    {cdp_value= cdp_init; cdp_unknown_pdps= 0})
-            })
+                    {cdp_value= cdp_init; cdp_unknown_pdps= 0}
+                )
+            }
+          )
           rras
     }
   in
@@ -548,7 +559,8 @@ let rrd_add_ds rrd now newds =
             ; rra_cdps=
                 Array.append rra.rra_cdps
                   [|{cdp_value= cdp_init; cdp_unknown_pdps= nunknowns}|]
-            })
+            }
+          )
           rrd.rrd_rras
     }
 
@@ -570,7 +582,8 @@ let rrd_remove_ds rrd ds_name =
               rra with
               rra_data= Utils.array_remove n rra.rra_data
             ; rra_cdps= Utils.array_remove n rra.rra_cdps
-            })
+            }
+          )
           rrd.rrd_rras
     }
 
@@ -584,9 +597,7 @@ let find_best_rras rrd pdp_interval cf start =
   let rras =
     match cf with
     | Some realcf ->
-        List.filter
-          (fun rra -> rra.rra_cf = realcf)
-          (Array.to_list rrd.rrd_rras)
+        List.filter (fun rra -> rra.rra_cf = realcf) (Array.to_list rrd.rrd_rras)
     | None ->
         Array.to_list rrd.rrd_rras
   in
@@ -674,7 +685,8 @@ let from_xml input =
           ; (* float_of_string "last_ds"; *)
             ds_value= float_of_string value
           ; ds_unknown_sec= float_of_string unknown_sec
-          })
+          }
+        )
         i
     in
     let dss = read_all "ds" read_ds i [] in
@@ -694,7 +706,8 @@ let from_xml input =
               {
                 cdp_value= float_of_string value
               ; cdp_unknown_pdps= int_of_string unknown_datapoints
-              })
+              }
+            )
             i
         in
         let cdps =
@@ -722,7 +735,8 @@ let from_xml input =
         let db =
           Array.init cols (fun i ->
               let ds = List.nth dss i in
-              Fring.make rows nan ds.ds_min ds.ds_max)
+              Fring.make rows nan ds.ds_min ds.ds_max
+          )
         in
         for i = 0 to cols - 1 do
           for j = 0 to rows - 1 do
@@ -760,7 +774,8 @@ let from_xml input =
             ; rra_data= database
             ; rra_cdps= Array.of_list cdps
             ; rra_updatehook= None
-            })
+            }
+          )
           i
       in
       rra
@@ -791,7 +806,8 @@ let from_xml input =
         List.map
           (fun name ->
             let x, _ = List.partition (( = ) name) ds_names in
-            (name, List.length x))
+            (name, List.length x)
+          )
           ds_names_set
       in
       let removals_required =
@@ -806,8 +822,10 @@ let from_xml input =
             else
               inner (rrd_remove_ds rrd name) (n - 1)
           in
-          inner rrd n)
-        rrd removals_required)
+          inner rrd n
+        )
+        rrd removals_required
+    )
     input
 
 let xml_to_output rrd output =
@@ -832,7 +850,8 @@ let xml_to_output rrd output =
         tag "value" (data (Utils.f_to_s ds.ds_value)) output ;
         tag "unknown_sec"
           (data (Printf.sprintf "%d" (int_of_float ds.ds_unknown_sec)))
-          output)
+          output
+      )
       output
   in
 
@@ -846,7 +865,8 @@ let xml_to_output rrd output =
         tag "value" (data (Utils.f_to_s cdp.cdp_value)) output ;
         tag "unknown_datapoints"
           (data (Printf.sprintf "%d" cdp.cdp_unknown_pdps))
-          output)
+          output
+      )
       output
   in
 
@@ -867,7 +887,8 @@ let xml_to_output rrd output =
               tag "v"
                 (data (Utils.f_to_s (Fring.peek rings.(col) (rows - row - 1))))
                 output
-            done)
+            done
+          )
           output
       done
   in
@@ -879,7 +900,8 @@ let xml_to_output rrd output =
         tag "pdp_per_row" (data (string_of_int rra.rra_pdp_cnt)) output ;
         tag "params" (tag "xff" (data (Utils.f_to_s rra.rra_xff))) output ;
         tag "cdp_prep" (fun output -> do_rra_cdps rra.rra_cdps output) output ;
-        tag "database" (fun output -> do_database rra.rra_data output) output)
+        tag "database" (fun output -> do_database rra.rra_data output) output
+      )
       output
   in
 
@@ -894,7 +916,8 @@ let xml_to_output rrd output =
         (data (Printf.sprintf "%Ld" (Int64.of_float rrd.last_updated)))
         output ;
       do_dss rrd.rrd_dss output ;
-      do_rras rrd.rrd_rras output)
+      do_rras rrd.rrd_rras output
+    )
     output
 
 module Json = struct
@@ -942,7 +965,8 @@ module Json = struct
         @@ Array.init rows (fun row ->
                array
                @@ Array.to_list
-               @@ Array.init cols (fun col -> get rings rows row col))
+               @@ Array.init cols (fun col -> get rings rows row col)
+           )
 
   let rra x =
     record
@@ -951,7 +975,8 @@ module Json = struct
       ; ("pdp_per_row", string "%d" x.rra_pdp_cnt)
       ; ("params", record [("xff", string "%s" (Utils.f_to_s x.rra_xff))])
       ; ( "cdp_prep"
-        , record [("ds", array @@ List.map cdp @@ Array.to_list x.rra_cdps)] )
+        , record [("ds", array @@ List.map cdp @@ Array.to_list x.rra_cdps)]
+        )
       ; ("database", database x.rra_data)
       ]
 
@@ -966,8 +991,7 @@ module Json = struct
       ]
 end
 
-let json_to_string rrd =
-  Yojson.to_string (Json.rrd rrd)
+let json_to_string rrd = Yojson.to_string (Json.rrd rrd)
 
 module Statefile_latency = struct
   type t = {id: string; latency: float option} [@@deriving rpc]

--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -902,9 +902,9 @@ module Json = struct
 
   let float x = string "%.2f" x
 
-  let record xs = `O xs
+  let record xs = `Assoc xs
 
-  let array xs = `A xs
+  let array xs = `List xs
 
   let datasource ds =
     record
@@ -967,9 +967,7 @@ module Json = struct
 end
 
 let json_to_string rrd =
-  let buf = Buffer.create 4096 in
-  let () = Ezjsonm.to_buffer buf (Json.rrd rrd) in
-  Buffer.contents buf
+  Yojson.to_string (Json.rrd rrd)
 
 module Statefile_latency = struct
   type t = {id: string; latency: float option} [@@deriving rpc]

--- a/lib/rrd_updates.ml
+++ b/lib/rrd_updates.ml
@@ -36,9 +36,8 @@ let string_of t =
   let leg_string =
     Printf.sprintf "[%s]"
       (String.concat ";"
-         (List.map
-            (fun l -> Printf.sprintf "\"%s\"" l)
-            (Array.to_list t.legend)))
+         (List.map (fun l -> Printf.sprintf "\"%s\"" l) (Array.to_list t.legend))
+      )
   in
 
   let data_string =
@@ -50,8 +49,13 @@ let string_of t =
                 (String.concat "; "
                    (List.map
                       (fun f -> Printf.sprintf "%0.4f" f)
-                      (Array.to_list row.row_data))))
-            (Array.to_list t.data)))
+                      (Array.to_list row.row_data)
+                   )
+                )
+            )
+            (Array.to_list t.data)
+         )
+      )
   in
 
   Printf.sprintf
@@ -129,7 +133,8 @@ let of_xml input =
         {
           time= Int64.of_string time
         ; row_data= Array.of_list (List.map (fun v -> float_of_string v) values)
-        })
+        }
+      )
       i
   in
 
@@ -151,7 +156,8 @@ let of_xml input =
         in
         let data = [||] in
         let meta = {start_time; step; end_time; legend; data} in
-        (meta, rows, columns))
+        (meta, rows, columns)
+      )
       i
   in
 
@@ -160,7 +166,8 @@ let of_xml input =
     (fun i ->
       let meta, _, _ = read_meta i in
       let data = read_block "data" read_data i in
-      {meta with data})
+      {meta with data}
+    )
     input
 
 let json_of_t t =
@@ -175,7 +182,8 @@ let json_of_t t =
     t.start_time t.step t.end_time (Array.length t.data) (Array.length t.legend) ;
   Printf.bprintf buffer "legend:[%s]},"
     (String.concat ","
-       (List.map (fun x -> "\"" ^ x ^ "\"") (Array.to_list t.legend))) ;
+       (List.map (fun x -> "\"" ^ x ^ "\"") (Array.to_list t.legend))
+    ) ;
   Printf.bprintf buffer "data:[" ;
   for i = 0 to Array.length t.data - 2 do
     do_data t.data.(i) ;
@@ -211,7 +219,8 @@ let create_multi prefixandrrds start interval cfopt =
            if start < 0L then
              Int64.(add start (of_float rrd.last_updated))
            else
-             start)
+             start
+       )
     |> List.fold_left min Int64.max_int
   in
 
@@ -219,7 +228,8 @@ let create_multi prefixandrrds start interval cfopt =
     List.map
       (fun (_prefix, rrd) ->
         (* Find the rrds that satisfy the requirements *)
-        Rrd.find_best_rras rrd pdp_interval cfopt start)
+        Rrd.find_best_rras rrd pdp_interval cfopt start
+      )
       prefixandrrds
   in
   let first_rra =
@@ -250,11 +260,15 @@ let create_multi prefixandrrds start interval cfopt =
                   (fun rra ->
                     Array.map
                       (fun name -> cf_type_to_string rra.rra_cf ^ ":" ^ name)
-                      ds_legends)
-                  rras)
+                      ds_legends
+                  )
+                  rras
+               )
            in
-           ds_legends_with_cf_prefix)
-         prefixandrrds rras)
+           ds_legends_with_cf_prefix
+         )
+         prefixandrrds rras
+      )
   in
 
   let rras = List.flatten rras in

--- a/lib_test/crowbar_tests.ml
+++ b/lib_test/crowbar_tests.ml
@@ -72,14 +72,16 @@ let ds_value =
    be infinity, leading to a comparison where the clamped value is out of range.
    This is not an issue when normally running as there are no data sources which
    such outrageous limits.
-   *)
+*)
 let ds =
   let open Rrd in
   let ds_type = Cb.(choose [const Derive; const Absolute; const Gauge]) in
   Cb.(
     map [ds_value; float; float; ds_type] (fun v x y typ ->
         let min, max = castd2s x y in
-        ds_create (ds_type_to_string typ) ~min ~max typ v))
+        ds_create (ds_type_to_string typ) ~min ~max typ v
+    )
+  )
 
 let rrd =
   Cb.(map [list1 int64; rra; ds]) (fun values rra ds ->
@@ -91,8 +93,10 @@ let rrd =
       List.iteri
         (fun i v ->
           let t = 5. *. (init_time +. float_of_int i) in
-          ds_update rrd t [|VT_Int64 v|] [|Fun.id|] (i = 0))
+          ds_update rrd t [|VT_Int64 v|] [|Fun.id|] (i = 0)
+        )
         values ;
-      rrd)
+      rrd
+  )
 
 let () = Cb.add_test ~name:"Out-of-bounds rates in archives" [rrd] test_ranges

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -7,7 +7,8 @@
     alcotest
     unix
     xapi-rrd
-    xapi-rrd.unix)
+    xapi-stdext-unix
+  )
 )
 
 (test
@@ -18,5 +19,5 @@
     crowbar
     unix
     xapi-rrd
-    xapi-rrd.unix)
+  )
 )

--- a/lib_test/unit_tests.ml
+++ b/lib_test/unit_tests.ml
@@ -112,8 +112,8 @@ let test_marshall_unmarshall rrd () =
   assert_rrds_equal rrd rrd'
 
 let test_export rrd () =
-  let check_same_as_rras (updates : Rrd_updates.row array)
-      (rras : Rrd.rra array) =
+  let check_same_as_rras (updates : Rrd_updates.row array) (rras : Rrd.rra array)
+      =
     let cf_count = Array.length rras in
     for i = 0 to cf_count - 1 do
       (* consolidation functions *)
@@ -142,7 +142,8 @@ let test_length_invariants rrd () =
       (Printf.sprintf
          "Number of elements in Datasource (%d) must be the same as Frings in \
           a RRA (%d)"
-         (Array.length dss) (Array.length frings))
+         (Array.length dss) (Array.length frings)
+      )
       (Array.length dss) (Array.length frings)
   in
   let check_length dss rra = check_length_of_fring dss rra.rra_data in
@@ -262,7 +263,8 @@ let create_rrd ?(rows = 2) values min max =
   List.iteri
     (fun i v ->
       let t = 5. *. (init_time +. float_of_int i) in
-      ds_update rrd t [|VT_Int64 v|] [|id; id; id; id|] (i = 0))
+      ds_update rrd t [|VT_Int64 v|] [|id; id; id; id|] (i = 0)
+    )
     values ;
   rrd
 
@@ -309,14 +311,17 @@ let suite_create_multi =
            Alcotest.(check int)
              (Printf.sprintf
                 "number of cols in legend must matche number of cols in row[%i]"
-                i)
+                i
+             )
              num_cols_in_legend
-             (Array.length r.RU.row_data))
+             (Array.length r.RU.row_data)
+       )
   in
   let test_no_rrds () =
     Alcotest.check_raises "should raise error" (Failure "hd") (fun () ->
         let _ = RU.create_multi [] 0L 1L None in
-        ())
+        ()
+    )
   in
   (* confusingly, rows in an rra are used to define the cols in the rrd_updates/ xml...
      essentially we usually expect 'rows' in each rrd to be the same (test_rows_with_same_num_cols)
@@ -328,12 +333,14 @@ let suite_create_multi =
       , [
           create_rrd ~rows:3 [0L; 5L; 10L] 0. 1.
         ; create_rrd ~rows:3 [1L; 6L; 11L] 0. 1.
-        ] )
+        ]
+      )
     ; ( "rows_with_different_num_cols"
       , [
           create_rrd ~rows:3 [0L; 5L; 10L] 0. 1.
         ; create_rrd ~rows:2 [1L; 6L; 11L] 0. 1.
-        ] )
+        ]
+      )
     ]
     |> List.map (fun (name, rrds) ->
            ( name
@@ -342,7 +349,9 @@ let suite_create_multi =
                let rrds =
                  List.mapi (fun i rrd -> (Printf.sprintf "row[%i]" i, rrd)) rrds
                in
-               RU.create_multi rrds 0L 1L None |> assert_size ))
+               RU.create_multi rrds 0L 1L None |> assert_size
+           )
+       )
   in
   ("no rrds", `Quick, test_no_rrds) :: valid_rrd_tests
 

--- a/unix/dune
+++ b/unix/dune
@@ -6,6 +6,7 @@
     unix
     uuidm
     xapi-rrd
+    xapi-stdext-pervasives
     xmlm
   )
 )

--- a/unix/rrd_unix.ml
+++ b/unix/rrd_unix.ml
@@ -26,7 +26,8 @@ let with_out_channel_output fd f =
   finally
     (fun () ->
       let output = Xmlm.make_output (`Channel oc) in
-      f output)
+      f output
+    )
     (fun () -> flush oc)
 
 let xml_to_fd rrd fd = with_out_channel_output fd (Rrd.xml_to_output rrd)

--- a/unix/rrd_unix.ml
+++ b/unix/rrd_unix.ml
@@ -19,75 +19,7 @@
  * @group Performance Monitoring
 *)
 
-let finally fct clean_f =
-  let result = try fct () with exn -> clean_f () ; raise exn in
-  clean_f () ; result
-
-let temp_file_in_dir otherfile =
-  let base_dir = Filename.dirname otherfile in
-  let rec keep_trying () =
-    try
-      let uuid = Uuidm.to_string (Uuidm.create `V4) in
-      let newfile = base_dir ^ "/" ^ uuid in
-      Unix.close
-        (Unix.openfile newfile [Unix.O_CREAT; Unix.O_TRUNC; Unix.O_EXCL] 0o600) ;
-      newfile
-    with Unix.Unix_error (Unix.EEXIST, _, _) -> keep_trying ()
-  in
-  keep_trying ()
-
-let unlink_safe file =
-  try Unix.unlink file with (* Unix.Unix_error (Unix.ENOENT, _ , _)*) _ -> ()
-
-let atomic_write_to_file fname perms f =
-  let tmp = temp_file_in_dir fname in
-  Unix.chmod tmp perms ;
-  finally
-    (fun () ->
-      let fd =
-        Unix.openfile tmp [Unix.O_WRONLY; Unix.O_CREAT] perms
-        (* ignored since the file exists *)
-      in
-      let result = finally (fun () -> f fd) (fun () -> Unix.close fd) in
-      Unix.rename tmp fname ;
-      (* Nb this only happens if an exception wasn't raised in the application of f *)
-      result)
-    (fun () -> unlink_safe tmp)
-
-let fd_blocks_fold block_size f start fd =
-  let block = Bytes.create block_size in
-  let rec fold acc =
-    let n = Unix.read fd block 0 block_size in
-    (* Consider making the interface explicitly use Substrings *)
-    let s =
-      if n = block_size then
-        Bytes.to_string block
-      else
-        Bytes.sub_string block 0 n
-    in
-    if n = 0 then acc else fold (f acc s)
-  in
-  fold start
-
-let buffer_of_fd fd =
-  fd_blocks_fold 1024
-    (fun b s -> Buffer.add_string b s ; b)
-    (Buffer.create 1024) fd
-
-let with_file file mode perms f =
-  let fd = Unix.openfile file mode perms in
-  let r = try f fd with exn -> Unix.close fd ; raise exn in
-  Unix.close fd ; r
-
-let buffer_of_file file_path =
-  with_file file_path [Unix.O_RDONLY] 0 buffer_of_fd
-
-let string_of_file file_path = Buffer.contents (buffer_of_file file_path)
-
-let of_file filename =
-  let body = string_of_file filename in
-  let input = Xmlm.make_input (`String (0, body)) in
-  Rrd.from_xml input
+let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
 let with_out_channel_output fd f =
   let oc = Unix.out_channel_of_descr fd in
@@ -106,6 +38,3 @@ let json_to_fd rrd fd =
 
 let to_fd ?(json = false) rrd fd =
   (if json then json_to_fd else xml_to_fd) rrd fd
-
-let to_file ?(json = false) rrd filename =
-  atomic_write_to_file filename 0o644 (to_fd ~json rrd)

--- a/unix/rrd_unix.mli
+++ b/unix/rrd_unix.mli
@@ -1,0 +1,19 @@
+(*
+  Copyright (C) Citrix Systems Inc.
+ 
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published
+  by the Free Software Foundation; version 2.1 only. with the special
+  exception on linking described in file LICENSE.
+ 
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+ *)
+(** RRD Unix module
+    This module provides Unix tools for dealing with RRDs
+ *)
+
+val to_fd : ?json:bool -> Rrd.rrd -> Unix.file_descr -> unit
+(** Serialize the rrd to xml / json and offer it through a file descriptor *)

--- a/xapi-rrd.opam
+++ b/xapi-rrd.opam
@@ -21,9 +21,11 @@ depends: [
   "rpclib"
   "xmlm"
   "uuidm"
+  "xapi-stdext-pervasives"
   "yojson"
   "alcotest" {with-test}
   "crowbar" {with-test}
+  "xapi-stdext-unix" {with-test}
 ]
 synopsis: "RRD library for use with xapi"
 description: """

--- a/xapi-rrd.opam
+++ b/xapi-rrd.opam
@@ -21,7 +21,7 @@ depends: [
   "rpclib"
   "xmlm"
   "uuidm"
-  "ezjsonm"
+  "yojson"
   "alcotest" {with-test}
   "crowbar" {with-test}
 ]


### PR DESCRIPTION
The code is ultimately only used to generate files for the testing marshalling and unmarshalling, which is strange since it's not used elsewhere