### PR TITLE
CA-371780: Remove quadratic cost in ds_update_name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+## v1.9.1 (28-Oct-2022)
+* CA-371780: Remove quadratic cost in ds_update_name
+
 ## v1.9.0 (02-Aug-2022)
 * ocamlformat: apply new formatting
 * unix: remove code from module

--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -16,6 +16,7 @@
 
 module Fring = Rrd_fring
 module Utils = Rrd_utils
+module StringMap = Map.Make (String)
 
 exception No_RRA_Available
 
@@ -445,21 +446,15 @@ let ds_update rrd timestamp values transforms new_domid =
 
 (** Update the rrd with named values rather than just an ordered array *)
 let ds_update_named rrd timestamp ~new_domid valuesandtransforms =
-  let identity x = x in
-  let ds_names = Array.map (fun ds -> ds.ds_name) rrd.rrd_dss in
-  let ds_values =
-    Array.map
-      (fun name ->
-        try fst (List.assoc name valuesandtransforms) with _ -> VT_Unknown
-      )
-      ds_names
+  let valuesandtransforms =
+    valuesandtransforms |> List.to_seq |> StringMap.of_seq
   in
-  let ds_transforms =
-    Array.map
-      (fun name ->
-        try snd (List.assoc name valuesandtransforms) with _ -> identity
-      )
-      ds_names
+  let get_value_and_transform {ds_name; _} =
+    Option.value ~default:(VT_Unknown, Fun.id)
+      (StringMap.find_opt ds_name valuesandtransforms)
+  in
+  let ds_values, ds_transforms =
+    Array.split (Array.map get_value_and_transform rrd.rrd_dss)
   in
   ds_update rrd timestamp ds_values ds_transforms new_domid
 

--- a/xapi-rrd.opam
+++ b/xapi-rrd.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "xen-api@lists.xen.org"
+maintainer: "Xapi project maintainers"
 authors: ["Dave Scott" "Jon Ludlam" "John Else"]
 homepage: "https://github.com/xapi-project/xcp-rrd"
 bug-reports: "https://github.com/xapi-project/xcp-rrd/issues"
@@ -13,11 +13,11 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml"
-  "dune" {build & >= "1.4.0"}
+  "ocaml" {>= "4.05"}
+  "dune" {>= "2.0.0"}
   "base-bigarray"
   "base-unix"
-  "ppx_deriving_rpc"
+  "ppx_deriving_rpc" {>= "6.1.0"}
   "rpclib"
   "xmlm"
   "uuidm"


### PR DESCRIPTION
Some perf runs I made with ~3000 paused VMs showed that xcp-rrdd was spending almost 60% of the samples in this function, due to quadratic cost of the linear search done for each item of the array. (twice)

Instead of a list, use a map with string comparison to avoid most of the cost, then do the search only once.

I elected to not change the interface of the function since most of the time building the associative list was done in an ad-hoc way anyway, so it can be built here instead

Measured using a microbenchmark: https://gist.github.com/psafont/5fa5d7279fff8542c9a5d98d5e7a235c

For 2000 VMs using 20 metrics each:
```
┌───────────────────────────────┬─────────────┬───────────────┬──────────┬─────────────┬────────────┐
│ Name                          │    Time/Run │       mWd/Run │ mjWd/Run │    Prom/Run │ Percentage │
├───────────────────────────────┼─────────────┼───────────────┼──────────┼─────────────┼────────────┤
│ reference with 40000 elements │ 29_883.37ms │         8.00w │  80.01kw │       6.71w │    100.00% │
│ map with 40000 elements       │     24.11ms │ 5_294_301.00w │ 388.35kw │ 268_350.39w │      0.08% │
└───────────────────────────────┴─────────────┴───────────────┴──────────┴─────────────┴────────────┘

```
500 VMs:
```
┌───────────────────────────────┬────────────┬───────────────┬──────────┬──────────┬────────────┐
│ Name                          │   Time/Run │       mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├───────────────────────────────┼────────────┼───────────────┼──────────┼──────────┼────────────┤
│ reference with 10000 elements │ 1_707.03ms │         8.00w │  20.00kw │          │    100.00% │
│ map with 10000 elements       │     5.01ms │ 1_178_907.00w │  91.62kw │  61.61kw │      0.29% │
└───────────────────────────────┴────────────┴───────────────┴──────────┴──────────┴────────────┘
```
50 VMs:
```
┌──────────────────────────────┬─────────────┬────────────┬──────────┬───────────┬────────────┐
│ Name                         │    Time/Run │    mWd/Run │ mjWd/Run │  Prom/Run │ Percentage │
├──────────────────────────────┼─────────────┼────────────┼──────────┼───────────┼────────────┤
│ reference with 1000 elements │ 17_563.41us │      8.00w │   2.00kw │     0.24w │    100.00% │
│ map with 1000 elements       │    379.32us │ 91_707.00w │   4.23kw │ 1_222.49w │      2.16% │
└──────────────────────────────┴─────────────┴────────────┴──────────┴───────────┴────────────┘
```

1 VM:
```
┌────────────────────────────┬──────────┬───────────┬──────────┬──────────┬────────────┐
│ Name                       │ Time/Run │   mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├────────────────────────────┼──────────┼───────────┼──────────┼──────────┼────────────┤
│ reference with 20 elements │   7.57us │    50.00w │          │          │    100.00% │
│ map with 20 elements       │   2.06us │ 1_042.00w │    0.35w │    0.35w │     27.20% │
└────────────────────────────┴──────────┴───────────┴──────────┴──────────┴────────────┘
```