### PR TITLE
Backport of CA-371780: Reduce cost of ds_update_name

### DIFF
--- a/.github/workflows/ocaml-ci.yml
+++ b/.github/workflows/ocaml-ci.yml
@@ -17,27 +17,24 @@ jobs:
 
       - name: Pull configuration from xs-opam
         run: |
-          curl --fail --silent https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env | cut -f2 -d " " > .env
+          curl --fail --silent https://raw.githubusercontent.com/xapi-project/xs-opam/release/yangtze/lcm/tools/xs-opam-ci.env | cut -f2 -d " " > .env
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v0.2.5
+        uses: falti/dotenv-action@v1.0.0
 
       - name: Use ocaml
-        uses: avsm/setup-ocaml@v1
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ steps.dotenv.outputs.ocaml_version_full }}
-          opam-repository: ${{ steps.dotenv.outputs.repository }}
+          ocaml-compiler: ${{ steps.dotenv.outputs.ocaml_version_full }}
+          opam-repositories: |
+            xs-opam: ${{ steps.dotenv.outputs.repository }}
 
       - name: Install dependencies
-        run: |
-          opam pin add . --no-action
-          opam depext -u ${{ env.package }}
-          opam install ${{ env.package }} --deps-only --with-test -v
+        run: opam install ${{ env.package }} --deps-only --with-test --with-doc -v
 
       - name: Build
-        run: |
-          opam exec -- make build
+        run: opam exec -- make build
 
       - name: Run tests
         run: opam exec -- make test

--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -438,6 +438,23 @@ let ds_update rrd timestamp values transforms new_domid =
       v2s
   )
 
+(* Adapted from Ocaml's Stdlib 4.13 *)
+let array_split x =
+  if x = [||] then [||], [||]
+  else begin
+    let open Array in
+    let a0, b0 = unsafe_get x 0 in
+    let n = length x in
+    let a = make n a0 in
+    let b = make n b0 in
+    for i = 1 to n - 1 do
+      let ai, bi = unsafe_get x i in
+      unsafe_set a i ai;
+      unsafe_set b i bi
+    done;
+    a, b
+  end
+
 (** Update the rrd with named values rather than just an ordered array *)
 let ds_update_named rrd timestamp ~new_domid valuesandtransforms =
   let valuesandtransforms =
@@ -448,7 +465,7 @@ let ds_update_named rrd timestamp ~new_domid valuesandtransforms =
       (StringMap.find_opt ds_name valuesandtransforms)
   in
   let ds_values, ds_transforms =
-    Array.split (Array.map get_value_and_transform rrd.rrd_dss)
+    array_split (Array.map get_value_and_transform rrd.rrd_dss)
   in
   ds_update rrd timestamp ds_values ds_transforms new_domid
 

--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -16,6 +16,7 @@
 
 module Fring = Rrd_fring
 module Utils = Rrd_utils
+module StringMap = Map.Make (String)
 
 exception No_RRA_Available
 
@@ -439,19 +440,15 @@ let ds_update rrd timestamp values transforms new_domid =
 
 (** Update the rrd with named values rather than just an ordered array *)
 let ds_update_named rrd timestamp ~new_domid valuesandtransforms =
-  let identity x = x in
-  let ds_names = Array.map (fun ds -> ds.ds_name) rrd.rrd_dss in
-  let ds_values =
-    Array.map
-      (fun name ->
-        try fst (List.assoc name valuesandtransforms) with _ -> VT_Unknown)
-      ds_names
+  let valuesandtransforms =
+    valuesandtransforms |> List.to_seq |> StringMap.of_seq
   in
-  let ds_transforms =
-    Array.map
-      (fun name ->
-        try snd (List.assoc name valuesandtransforms) with _ -> identity)
-      ds_names
+  let get_value_and_transform {ds_name; _} =
+    Option.value ~default:(VT_Unknown, Fun.id)
+      (StringMap.find_opt ds_name valuesandtransforms)
+  in
+  let ds_values, ds_transforms =
+    Array.split (Array.map get_value_and_transform rrd.rrd_dss)
   in
   ds_update rrd timestamp ds_values ds_transforms new_domid
 


### PR DESCRIPTION
This included a port of Array.split from ocaml's 4.13 to be able to compile the code

Note that the base branch contains commits included in the master branch since the last released version v1.8.1. These changes include:
- Fixes in tests
- Changes in dune and opam metadata
- Changes to be able to format code with ocamlformat
- Move the CI from travis to github

The changes about ocamlformat are small and removes some warnings, while I would have preferred to keep them out I'd rather use most of the master branch as base rather than adding more commits to this branch that are untested