### PR TITLE
CA-378301: Duplicate fd before creating out_channels

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+## v1.9.2 (13-Jun-2023)
+* CA-378301: Avoid memory leaks when writing XML
+
 ## v1.9.1 (28-Oct-2022)
 * CA-371780: Remove quadratic cost in ds_update_name
 

--- a/unix/rrd_unix.ml
+++ b/unix/rrd_unix.ml
@@ -22,13 +22,13 @@
 let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
 let with_out_channel_output fd f =
-  let oc = Unix.out_channel_of_descr fd in
+  let oc = Unix.(out_channel_of_descr (dup fd)) in
   finally
     (fun () ->
       let output = Xmlm.make_output (`Channel oc) in
       f output
     )
-    (fun () -> flush oc)
+    (fun () -> Out_channel.close_noerr oc)
 
 let xml_to_fd rrd fd = with_out_channel_output fd (Rrd.xml_to_output rrd)
 


### PR DESCRIPTION
There are two issues that are worked around here:
- Because the function doesn't own the file descriptor, the channel couldn't be closed. When this was used on a socket, it could have been closed and forced an error on the flush, never releasing the memory
- Because the channel is kept alive, and poiting to an FD, reusing the FD will lead to writing data to an unrelated file / socket

Duplicating the file descriptor allows the function to control the whole life-cycle of the underlying FD and be able to close it, triggering it to be GC'd