### PR TITLE
CA-378301: Avoid memory leaks when writing XML

### DIFF
--- a/unix/rrd_unix.ml
+++ b/unix/rrd_unix.ml
@@ -90,12 +90,12 @@ let of_file filename =
   Rrd.from_xml input
 
 let with_out_channel_output fd f =
-  let oc = Unix.out_channel_of_descr fd in
+  let oc = Unix.(out_channel_of_descr (dup fd)) in
   finally
     (fun () ->
       let output = Xmlm.make_output (`Channel oc) in
       f output)
-    (fun () -> flush oc)
+    (fun () -> close_out_noerr oc)
 
 let xml_to_fd rrd fd = with_out_channel_output fd (Rrd.xml_to_output rrd)
 


### PR DESCRIPTION
There are two issues that are worked around here:
- Because the function doesn't own the file descriptor, the channel
  couldn't be closed. When this was used on a socket, it could have been
  closed and forced an error on the flush, never releasing the memory
- Because the channel is kept alive, and poiting to an FD, reusing the
  FD will lead to writing data to an unrelated file / socket
Duplicating the file descriptor allows the function to control the whole
life-cycle of the underlying FD and be able to close it, triggering it
to be GC'd

cherry-pick from 295448796d6e18c7d08126967357d8da94f7f908