### PR TITLE
rrd_updates: Replace ad-hoc json serialization with yojson

### DIFF
--- a/.github/workflows/ocaml-ci.yml
+++ b/.github/workflows/ocaml-ci.yml
@@ -8,12 +8,10 @@ jobs:
   ocaml-test:
     name: Ocaml tests
     runs-on: ubuntu-20.04
-    env:
-      package: "xapi-rrd"
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Pull configuration from xs-opam
         run: |
@@ -21,24 +19,20 @@ jobs:
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v0.2.5
+        uses: falti/dotenv-action@v1.0.4
 
       - name: Use ocaml
-        uses: avsm/setup-ocaml@v1
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ steps.dotenv.outputs.ocaml_version_full }}
-          opam-repository: ${{ steps.dotenv.outputs.repository }}
+          ocaml-compiler: ${{ steps.dotenv.outputs.ocaml_version_full }}
+          opam-repositories: |
+            xs-opam: ${{ steps.dotenv.outputs.repository }}
 
       - name: Install dependencies
-        run: |
-          opam pin add . --no-action
-          opam depext -u ${{ env.package }}
-          opam install ${{ env.package }} --deps-only --with-test -v
+        run: opam install . --deps-only --with-test -v
 
       - name: Build
-        run: |
-          opam exec -- make build
+        run: opam exec -- make build
 
       - name: Run tests
         run: opam exec -- make test
-

--- a/lib/rrd_utils.ml
+++ b/lib/rrd_utils.ml
@@ -86,7 +86,7 @@ let rec setify = function
 let f_to_s f =
   match classify_float f with
   | FP_normal | FP_subnormal ->
-      Printf.sprintf "%0.4f" f
+      Printf.sprintf "%0.5g" f
   | FP_nan ->
       "NaN"
   | FP_infinite ->

--- a/lib_test/unit_tests.ml
+++ b/lib_test/unit_tests.ml
@@ -1,16 +1,10 @@
 open Rrd
 
-(* Default alcotest checker fails when comparing NaNs and Infinities,
- * we need leeway to account for loss of precision during serialization. *)
-let float eps =
-  let same x y = Float.equal x y || Float.abs (x -. y) <= eps in
-  Alcotest.testable Fmt.float same
-
 (* pick between absolute or relative tolerance of a number *)
 let tolerance x = max 1e-4 (abs_float x *. 1e-12)
 
 let compare_float message x y =
-  Alcotest.check (float @@ tolerance x) message x y
+  Alcotest.(check @@ float @@ tolerance x) message x y
 
 let assert_ds_equal d1 d2 =
   Alcotest.(check string) __LOC__ d1.ds_name d2.ds_name ;
@@ -34,7 +28,8 @@ let assert_fring_equal f1 f2 =
   for i = 0 to Fring.length f1 - 1 do
     let peek1 = Fring.peek f1 i in
     let peek2 = Fring.peek f2 i in
-    Alcotest.check (float @@ tolerance peek1) "FRing value" peek1 peek2
+    let msg = Printf.sprintf "Fring value must match: %f, %f" peek1 peek2 in
+    Alcotest.(check @@ float @@ tolerance peek1) msg peek1 peek2
   done
 
 let assert_rra_equal a1 a2 =


### PR DESCRIPTION
Also consolidates the code to serialize floats so all of them are printed consistently.

All numbers are serialized as quoted strings, like the other endpoints. This is a change in the /rrd_updates endpoint.

Before:
```
# Printf.printf "%s" (Rrd_updates.export ~json:true [("", an_rrd)] 0L 5L None) ;;
{meta: {start:50,step:50,end:0,rows:1,columns:12,legend:["AVERAGE:derive","AVERAGE:absolute","AVERAGE:gauge","MIN:derive","MIN:absolute","MIN:gauge","MAX:derive","MAX:absolute","MAX:gauge","LAST:derive","LAST:absolute","LAST:gauge"]},data:[{t:0,values:[NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN]}]}
```

Now:
```
# Printf.printf "%s" (Rrd_updates.export ~json:true [("", an_rrd)] 0L 5L None) ;;
{"meta":{"start":"50","step":"50","end":"0","rows":"1","columns":"12","legend":["AVERAGE:derive","AVERAGE:absolute","AVERAGE:gauge","MIN:derive","MIN:absolute","MIN:gauge","MAX:derive","MAX:absolute","MAX:gauge","LAST:derive","LAST:absolute","LAST:gauge"],"data":[{"t":"0","values":["NaN","NaN","NaN","NaN","NaN","NaN","NaN","NaN","NaN","NaN","NaN","NaN"]}]}}
```