### PR TITLE
lib: remove Failure "hd" exceptions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+## v1.11.0 (16-Nov-2023)
+* lib: remove Failure "hd" exceptions
+
 ## v1.10.0 (02-Aug-2023)
 * rrd_updates: use yojson instead of ad-hoc json serialization
 

--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -633,7 +633,11 @@ let query_named_ds rrd now ds_name cf =
     raise (Invalid_data_source ds_name)
   else
     let rras = find_best_rras rrd 0 (Some cf) (Int64.of_float now) in
-    Fring.peek (List.hd rras).rra_data.(n) 0
+    match rras with
+    | [] ->
+        raise No_RRA_Available
+    | rra :: _ ->
+        Fring.peek rra.rra_data.(n) 0
 
 (******************************************************************************)
 (* Marshalling/Unmarshalling functions                                        *)

--- a/lib_test/unit_tests.ml
+++ b/lib_test/unit_tests.ml
@@ -313,7 +313,7 @@ let suite_create_multi =
        )
   in
   let test_no_rrds () =
-    Alcotest.check_raises "should raise error" (Failure "hd") (fun () ->
+    Alcotest.check_raises "should raise error" (No_RRA_Available) (fun () ->
         let _ = RU.create_multi [] 0L 1L None in
         ()
     )


### PR DESCRIPTION
Instead raise the semantically correct No_RRA_available.

There's one last List.hd in the code, but it's correctly guarded so it cannot ever be used with an empty list.