### PR TITLE
Fixed typo in ds field minimal_heartbeat.

### DIFF
--- a/lib/rrd.ml
+++ b/lib/rrd.ml
@@ -939,7 +939,7 @@ module Json = struct
       [
         ("name", string ds.ds_name)
       ; ("type", string (ds_type_to_string ds.ds_ty))
-      ; ("minimal_hearbeat", float ds.ds_mrhb)
+      ; ("minimal_heartbeat", float ds.ds_mrhb)
       ; ("min", float ds.ds_min)
       ; ("max", float ds.ds_max)
       ; ("last_ds", string (ds_value_to_string ds.ds_last))


### PR DESCRIPTION
I hadn't notice this before I started deserializing the data for CP-33676 - it's correct in the XML host_rrds/vm_rrds, but the JSON ones have the typo:
```
{"version":"0003","step":"5","lastupdate":"1702081428.1667","ds":[{"name":"cpu0","type":"DERIVE","minimal_hearbeat":"300.0000","min":"0.0",...
```